### PR TITLE
Fix error: Object doesn't support property or method 'forEach'

### DIFF
--- a/src/directive/sort.directive.ts
+++ b/src/directive/sort.directive.ts
@@ -61,10 +61,10 @@ export class JhiSortDirective {
 
     private resetClasses() {
         const allThIcons = this.element.querySelectorAll(this.sortIconSelector);
-        allThIcons.forEach((value) => {
-            value.classList.remove(this.sortAscIcon);
-            value.classList.remove(this.sortDescIcon);
-            value.classList.add(this.sortIcon);
-        });
+        for (var i = 0; i < allThIcons.length; i++) {
+            allThIcons[i].classList.remove(this.sortAscIcon);
+            allThIcons[i].classList.remove(this.sortDescIcon);
+            allThIcons[i].classList.add(this.sortIcon);
+        }
     };
 }

--- a/src/directive/sort.directive.ts
+++ b/src/directive/sort.directive.ts
@@ -65,6 +65,6 @@ export class JhiSortDirective {
             allThIcons[i].classList.remove(this.sortAscIcon);
             allThIcons[i].classList.remove(this.sortDescIcon);
             allThIcons[i].classList.add(this.sortIcon);
-        }
+        };
     };
 }


### PR DESCRIPTION
On IE when you click icon "sort", this error happen: "Object doesn't support property or method 'forEach'".